### PR TITLE
[fix]table id init, build empty table

### DIFF
--- a/src/level.rs
+++ b/src/level.rs
@@ -64,7 +64,7 @@ impl LevelsControllerInner {
         let path = &opt.dir;
         let (manifest, l0_ids) = ManifestFile::open(path)?;
         let id_level = manifest.get_id_level();
-        let next_sst_id = AtomicU64::new(id_level.keys().copied().max().unwrap_or(0));
+        let next_sst_id = AtomicU64::new(id_level.keys().copied().max().unwrap_or(0) + 1);
         let mut levels = vec![vec![]; opt.num_levels];
 
         for id in l0_ids {

--- a/src/lsm_storage.rs
+++ b/src/lsm_storage.rs
@@ -241,6 +241,10 @@ impl LsmStorage {
             }
         }
 
+        if map.is_empty() {
+            return Ok(());
+        }
+
         let mut builder = SsTableBuilder::new(self.opt.clone());
         for (key, value) in &map {
             builder.add(key, value).unwrap();

--- a/src/table/builder.rs
+++ b/src/table/builder.rs
@@ -64,6 +64,10 @@ impl SsTableBuilder {
     }
 
     fn block_build(&mut self) -> Result<()> {
+        if self.block_builder.is_empty() {
+            return Ok(());
+        }
+
         let mut builder = BlockBuilder::new(self.opt.block_size);
         std::mem::swap(&mut self.block_builder, &mut builder);
 

--- a/src/tests/storage.rs
+++ b/src/tests/storage.rs
@@ -185,3 +185,15 @@ fn test_storage_scan_memtable_2_after_sync() {
         vec![(Bytes::from("2"), Bytes::from("2333"))],
     );
 }
+
+#[test]
+fn test_storage_close() {
+    use crate::lsm_storage::LsmStorage;
+    let dir = tempdir().unwrap();
+    let storage = LsmStorage::open(LsmOptions::default().path(&dir)).unwrap();
+    storage.put(b"1", b"233").unwrap();
+    assert_eq!(&storage.get(b"1").unwrap().unwrap()[..], b"233");
+    drop(storage);
+    let storage = LsmStorage::open(LsmOptions::default().path(&dir)).unwrap();
+    assert_eq!(&storage.get(b"1").unwrap().unwrap()[..], b"233");
+}

--- a/src/tests/storage.rs
+++ b/src/tests/storage.rs
@@ -197,3 +197,15 @@ fn test_storage_close() {
     let storage = LsmStorage::open(LsmOptions::default().path(&dir)).unwrap();
     assert_eq!(&storage.get(b"1").unwrap().unwrap()[..], b"233");
 }
+
+#[test]
+fn test_storage_close2() {
+    use crate::lsm_storage::LsmStorage;
+    let dir = tempdir().unwrap();
+    let storage = LsmStorage::open(LsmOptions::default().path(&dir)).unwrap();
+    storage.put(b"1", b"233").unwrap();
+    assert_eq!(&storage.get(b"1").unwrap().unwrap()[..], b"233");
+    drop(storage);
+    let storage = LsmStorage::open(LsmOptions::default().path(&dir)).unwrap();
+    storage.put(b"2", b"233").unwrap();
+}


### PR DESCRIPTION
Two problem
1. build empty table 
```rust
fn test_storage_close() {
    use crate::lsm_storage::LsmStorage;
    let dir = tempdir().unwrap();
    let storage = LsmStorage::open(LsmOptions::default().path(&dir)).unwrap();
    storage.put(b"1", b"233").unwrap();
    assert_eq!(&storage.get(b"1").unwrap().unwrap()[..], b"233");
    drop(storage);
    let storage = LsmStorage::open(LsmOptions::default().path(&dir)).unwrap();
    assert_eq!(&storage.get(b"1").unwrap().unwrap()[..], b"233");
}
```

2. use previous id: OS error File exists
```rust
#[test]
fn test_storage_close2() {
    use crate::lsm_storage::LsmStorage;
    let dir = tempdir().unwrap();
    let storage = LsmStorage::open(LsmOptions::default().path(&dir)).unwrap();
    storage.put(b"1", b"233").unwrap();
    assert_eq!(&storage.get(b"1").unwrap().unwrap()[..], b"233");
    drop(storage);
    let storage = LsmStorage::open(LsmOptions::default().path(&dir)).unwrap();
    storage.put(b"2", b"233").unwrap();
}
```